### PR TITLE
Modifying JWT Handling

### DIFF
--- a/src/main/java/com/damienwesterman/defensedrill/gateway/filter/AuthenticationFilter.java
+++ b/src/main/java/com/damienwesterman/defensedrill/gateway/filter/AuthenticationFilter.java
@@ -95,9 +95,27 @@ public class AuthenticationFilter
 
                     String requestedEndpoint = exchange.getRequest().getURI().getPath();
 
-                    exchange.getResponse().getHeaders().set(
-                        HttpHeaders.LOCATION,
-                        "/login?error=" + errorMessage + "&redirect=" + requestedEndpoint);
+                    if (requestedEndpoint.startsWith("/htmx")) {
+                        // If they were trying to access an HTMX endpoint, we need to specify the redirect
+                        // endpoint and make sure to redirect their entire page
+
+                        String redirectEndpoint = "/";
+                        if (requestedEndpoint.startsWith("/htmx/drill")) {
+                            redirectEndpoint = "/modify/drill";
+                        } else if (requestedEndpoint.startsWith("/htmx/category")) {
+                            redirectEndpoint = "/modify/category";
+                        } else if (requestedEndpoint.startsWith("/htmx/sub_category")) {
+                            redirectEndpoint = "/modify/sub_category";
+                        }
+
+                        exchange.getResponse().getHeaders().set(
+                            "HX-Redirect",
+                            "/login?error=" + errorMessage + "&redirect=" + redirectEndpoint);
+                    } else {
+                        exchange.getResponse().getHeaders().set(
+                            HttpHeaders.LOCATION,
+                            "/login?error=" + errorMessage + "&redirect=" + requestedEndpoint);
+                    }
                 }
 
                 // Do not forward request

--- a/src/main/java/com/damienwesterman/defensedrill/gateway/filter/AuthenticationFilter.java
+++ b/src/main/java/com/damienwesterman/defensedrill/gateway/filter/AuthenticationFilter.java
@@ -87,6 +87,8 @@ public class AuthenticationFilter
                     String errorMessage = "";
                     if (jwt.isBlank()) {
                         errorMessage = "Please%20Log%20In";
+                    } else if (jwtService.isTokenExpired(jwt)) {
+                        errorMessage = "Session%20Expired,%20Please%20Sign%20In%20Again";
                     } else {
                         errorMessage = "Not%20Authorized";
                     }

--- a/src/main/java/com/damienwesterman/defensedrill/gateway/service/JwtService.java
+++ b/src/main/java/com/damienwesterman/defensedrill/gateway/service/JwtService.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Service;
 import com.damienwesterman.defensedrill.gateway.util.Constants;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
@@ -90,6 +91,32 @@ public class JwtService {
      */
     public boolean isTokenValid(@NonNull String jwt) {
         return Optional.ofNullable(getClaims(jwt)).isPresent();
+    }
+
+    /**
+     * Check if a JWT is expired.
+     * <br><br>
+     * !! NOTE !! Just because a token is not expired does NOT guarantee it is valid
+     *
+     * @param jwt String JWT
+     * @return true/false if the token has expired
+     */
+    public boolean isTokenExpired(@NonNull String jwt) {
+        if (jwt.isBlank()) {
+            return false;
+        }
+
+        try {
+            Jwts.parser()
+                .verifyWith(generatePublicKey())
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload();
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
We want to make some JWT handling different for better user feedback:
- We want to explicitly state when a JWT is expired rather than providing a default "Unauthorized" message
- When accessing an HTMX endpoint, there is an issue that the login screen is returned in the HTMX container rather than redirecting the entire page
   - So instead, we want to redirect to the login page
   - Once logged in, we want to return the user to whatever modify screen they were at